### PR TITLE
devtools: python: Append nativesdk class to python3-ply

### DIFF
--- a/recipes-devtools/python/python3-ply_%.bbappend
+++ b/recipes-devtools/python/python3-ply_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "nativesdk"


### PR DESCRIPTION
This change is prerequisite to allow addition of python3-ply package into native SDK.
python3-ply is one of the python package required for building libcamera using host tools from SDK.